### PR TITLE
Augment ContentDiscoveryIntent with more context

### DIFF
--- a/src/modules/discovery.json
+++ b/src/modules/discovery.json
@@ -46,7 +46,9 @@
         "summary": "discovery policy opt-in/outs",
         "schema": {
           "oneOf": [
-            { "$ref": "https://meta.comcast.com/firebolt/types#/definitions/ListenResponse" },
+            {
+              "$ref": "https://meta.comcast.com/firebolt/types#/definitions/ListenResponse"
+            },
             { "$ref": "#/components/schemas/DiscoveryPolicy" }
           ]
         }
@@ -131,18 +133,10 @@
                       "price": 2.99,
                       "videoQuality": ["UHD"],
                       "audioProfile": ["dolbyAtmos"],
-                      "audioLanguages": [
-                        "en"
-                      ],
-                      "closedCaptions": [
-                        "en"
-                      ],
-                      "subtitles": [
-                        "es"
-                      ],
-                      "audioDescriptions": [
-                        "en"
-                      ]
+                      "audioLanguages": ["en"],
+                      "closedCaptions": ["en"],
+                      "subtitles": ["es"],
+                      "audioDescriptions": ["en"]
                     }
                   ]
                 }
@@ -192,18 +186,10 @@
                       "price": 2.99,
                       "videoQuality": ["UHD"],
                       "audioProfile": ["dolbyAtmos"],
-                      "audioLanguages": [
-                        "en"
-                      ],
-                      "closedCaptions": [
-                        "en"
-                      ],
-                      "subtitles": [
-                        "es"
-                      ],
-                      "audioDescriptions": [
-                        "en"
-                      ]
+                      "audioLanguages": ["en"],
+                      "closedCaptions": ["en"],
+                      "subtitles": ["es"],
+                      "audioDescriptions": ["en"]
                     }
                   ]
                 },
@@ -224,12 +210,8 @@
                         "entitled": true,
                         "videoQuality": ["HD"],
                         "audioProfile": ["dolbyAtmos"],
-                        "audioLanguages": [
-                          "en"
-                        ],
-                        "closedCaptions": [
-                          "en"
-                        ]
+                        "audioLanguages": ["en"],
+                        "closedCaptions": ["en"]
                       }
                     ]
                   }
@@ -292,12 +274,8 @@
                         "offeringType": "free",
                         "videoQuality": ["SD"],
                         "audioProfile": ["stereo"],
-                        "audioLanguages": [
-                          "en"
-                        ],
-                        "closedCaptions": [
-                          "en"
-                        ]
+                        "audioLanguages": ["en"],
+                        "closedCaptions": ["en"]
                       }
                     ]
                   },
@@ -330,12 +308,8 @@
                         "offeringType": "free",
                         "videoQuality": ["SD"],
                         "audioProfile": ["stereo"],
-                        "audioLanguages": [
-                          "en"
-                        ],
-                        "closedCaptions": [
-                          "en"
-                        ]
+                        "audioLanguages": ["en"],
+                        "closedCaptions": ["en"]
                       }
                     ]
                   },
@@ -368,12 +342,8 @@
                         "offeringType": "free",
                         "videoQuality": ["SD"],
                         "audioProfile": ["stereo"],
-                        "audioLanguages": [
-                          "en"
-                        ],
-                        "closedCaptions": [
-                          "en"
-                        ]
+                        "audioLanguages": ["en"],
+                        "closedCaptions": ["en"]
                       }
                     ]
                   }
@@ -454,18 +424,10 @@
                         "price": 2.99,
                         "videoQuality": ["UHD"],
                         "audioProfile": ["dolbyAtmos"],
-                        "audioLanguages": [
-                          "en"
-                        ],
-                        "closedCaptions": [
-                          "en"
-                        ],
-                        "subtitles": [
-                          "es"
-                        ],
-                        "audioDescriptions": [
-                          "en"
-                        ]
+                        "audioLanguages": ["en"],
+                        "closedCaptions": ["en"],
+                        "subtitles": ["es"],
+                        "audioDescriptions": ["en"]
                       }
                     ]
                   }
@@ -966,7 +928,7 @@
             "name": "success",
             "value": true
           }
-        }                           
+        }
       ]
     },
     {
@@ -1036,7 +998,7 @@
           "name": "rpc-only"
         }
       ],
-      "summary": "listen to `entityInfo` pull events",
+      "summary": "listen to entityInfo pull events",
       "params": [
         {
           "name": "listen",
@@ -1062,7 +1024,7 @@
       },
       "examples": [
         {
-          "name": "Platform requests entity `abc`",
+          "name": "Platform requests entity abc",
           "params": [
             {
               "name": "listen",
@@ -1249,12 +1211,7 @@
         "title": "EntityInfo",
         "description": "An EntityInfo object represents an \"entity\" on the platform. Currently, only entities of type `program` are supported. `programType` must be supplied to identify the program type.\n\nAdditionally, EntityInfo objects must specify a properly formed\nContentIdentifiers object, `entityType`, and `title`.  The app should provide\nthe `synopsis` property for a good user experience if the content\nmetadata is not available another way.\n\nThe ContentIdentifiers must be sufficient for navigating the user to the\nappropriate entity or detail screen via a `detail` intent or deep link.\n\nEntityInfo objects must provide at least one WayToWatch object when returned as\npart of an `entityInfo` method and a streamable asset is available to the user.\nIt is optional for the `purchasedContent` method, but recommended because the UI\nmay use those data.",
         "type": "object",
-        "required": [
-          "identifiers",
-          "entityType",
-          "programType",
-          "title"
-        ],
+        "required": ["identifiers", "entityType", "programType", "title"],
         "properties": {
           "identifiers": {
             "$ref": "#/components/schemas/ContentIdentifiers"
@@ -1306,9 +1263,7 @@
       "WayToWatch": {
         "title": "WayToWatch",
         "type": "object",
-        "required": [
-          "identifiers"
-        ],
+        "required": ["identifiers"],
         "properties": {
           "identifiers": {
             "$ref": "#/components/schemas/ContentIdentifiers"
@@ -1342,11 +1297,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "SD",
-                "HD",
-                "UHD"
-              ]
+              "enum": ["SD", "HD", "UHD"]
             },
             "description": "List of the video qualities available via the WayToWatch."
           },
@@ -1391,10 +1342,7 @@
       "ContentRating": {
         "title": "ContentRating",
         "type": "object",
-        "required": [
-          "scheme",
-          "rating"
-        ],
+        "required": ["scheme", "rating"],
         "properties": {
           "scheme": {
             "type": "string",
@@ -1458,14 +1406,9 @@
             "type": "string"
           }
         },
-        "required": [
-          "correlationId"
-        ],
+        "required": ["correlationId"],
         "propertyNames": {
-          "enum": [
-            "correlationId",
-            "parameters"
-          ]
+          "enum": ["correlationId", "parameters"]
         },
         "examples": [
           {
@@ -1481,15 +1424,9 @@
             "type": "string"
           }
         },
-        "required": [
-          "correlationId",
-          "result"
-        ],
+        "required": ["correlationId", "result"],
         "propertyNames": {
-          "enum": [
-            "correlationId",
-            "result"
-          ]
+          "enum": ["correlationId", "result"]
         },
         "examples": [
           {
@@ -1510,10 +1447,7 @@
                 "$ref": "#/components/schemas/EntityInfoParameters"
               }
             },
-            "required": [
-              "correlationId",
-              "parameters"
-            ]
+            "required": ["correlationId", "parameters"]
           }
         ],
         "examples": [
@@ -1536,9 +1470,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "entityId"
-        ],
+        "required": ["entityId"],
         "additionalProperties": false,
         "examples": [
           {
@@ -1581,10 +1513,7 @@
             }
           }
         },
-        "required": [
-          "expires",
-          "entity"
-        ],
+        "required": ["expires", "entity"],
         "additionalProperties": false
       },
       "PurchasedContentFederatedRequest": {
@@ -1600,10 +1529,7 @@
                 "$ref": "#/components/schemas/PurchasedContentParameters"
               }
             },
-            "required": [
-              "correlationId",
-              "parameters"
-            ]
+            "required": ["correlationId", "parameters"]
           }
         ],
         "examples": [
@@ -1630,9 +1556,7 @@
             "$ref": "https://meta.comcast.com/firebolt/entertainment#/definitions/ProgramType"
           }
         },
-        "required": [
-          "limit"
-        ],
+        "required": ["limit"],
         "additionalProperties": false,
         "examples": [
           {
@@ -1675,11 +1599,7 @@
             }
           }
         },
-        "required": [
-          "expires",
-          "totalCount",
-          "entries"
-        ],
+        "required": ["expires", "totalCount", "entries"],
         "additionalProperties": false
       }
     }

--- a/src/schemas/intents.json
+++ b/src/schemas/intents.json
@@ -795,6 +795,41 @@
                 "query": {
                   "type": "string"
                 },
+                "filters": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "key": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "minItems": 1,
+                  "maxItems": 100
+                },
+                "keywords": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "keyword": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "appId": {
+                        "$ref": "#/definitions/Identifier"
+                      }
+                    }
+                  },
+                  "minItems": 1,
+                  "maxItems": 100
+                },
                 "menus": {
                   "type": "array",
                   "items": {

--- a/src/schemas/intents.json
+++ b/src/schemas/intents.json
@@ -20,10 +20,7 @@
         },
         {
           "type": "object",
-          "required": [
-            "appId",
-            "intent"
-          ],
+          "required": ["appId", "intent"],
           "properties": {
             "appId": {
               "type": "string"
@@ -36,12 +33,7 @@
             }
           },
           "propertyNames": {
-            "enum": [
-              "type",
-              "appId",
-              "intent",
-              "metadata"
-            ]
+            "enum": ["type", "appId", "intent", "metadata"]
           }
         }
       ],
@@ -88,9 +80,7 @@
         },
         {
           "type": "object",
-          "required": [
-            "intent"
-          ],
+          "required": ["intent"],
           "properties": {
             "intent": {
               "oneOf": [
@@ -113,11 +103,7 @@
             }
           },
           "propertyNames": {
-            "enum": [
-              "type",
-              "intent",
-              "metadata"
-            ]
+            "enum": ["type", "intent", "metadata"]
           }
         }
       ],
@@ -143,9 +129,7 @@
             "action": "discovery",
             "data": {
               "query": "christmas",
-              "menus": [
-                "christmas-menu"
-              ],
+              "menus": ["christmas-menu"],
               "federation": [
                 {
                   "appId": "netflix",
@@ -163,27 +147,18 @@
     "Intent": {
       "description": "A Firebolt compliant representation of a user intention.",
       "type": "object",
-      "required": [
-        "action",
-        "context"
-      ],
+      "required": ["action", "context"],
       "properties": {
         "action": {
           "type": "string"
         },
         "context": {
           "type": "object",
-          "required": [
-            "source"
-          ],
+          "required": ["source"],
           "properties": {
             "source": {
               "type": "string",
-              "enum": [
-                "voice",
-                "editorial",
-                "device"
-              ]
+              "enum": ["voice", "editorial", "device"]
             }
           }
         }
@@ -192,11 +167,7 @@
     "IntentProperties": {
       "type": "object",
       "propertyNames": {
-        "enum": [
-          "action",
-          "data",
-          "context"
-        ]
+        "enum": ["action", "data", "context"]
       }
     },
     "NavigationIntent": {
@@ -356,9 +327,7 @@
         },
         {
           "type": "object",
-          "required": [
-            "data"
-          ],
+          "required": ["data"],
           "properties": {
             "action": {
               "const": "entity"
@@ -416,11 +385,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "entityType",
-        "programType",
-        "entityId"
-      ]
+      "required": ["entityType", "programType", "entityId"]
     },
     "MovieEntity": {
       "title": "MovieEntity",
@@ -432,11 +397,7 @@
           "description": "A Firebolt compliant representation of a Movie entity.",
           "title": "MovieEntity",
           "type": "object",
-          "required": [
-            "entityType",
-            "programType",
-            "entityId"
-          ],
+          "required": ["entityType", "programType", "entityId"],
           "properties": {
             "entityType": {
               "const": "program"
@@ -529,12 +490,7 @@
         },
         {
           "type": "object",
-          "required": [
-            "entityType",
-            "programType",
-            "entityId",
-            "seriesId"
-          ],
+          "required": ["entityType", "programType", "entityId", "seriesId"],
           "properties": {
             "entityType": {
               "const": "program"
@@ -577,11 +533,7 @@
         {
           "description": "A Firebolt compliant representation of a TV Series entity.",
           "type": "object",
-          "required": [
-            "entityType",
-            "programType",
-            "entityId"
-          ],
+          "required": ["entityType", "programType", "entityId"],
           "properties": {
             "entityType": {
               "const": "program"
@@ -620,10 +572,7 @@
         {
           "description": "A Firebolt compliant representation of the remaining entity types.",
           "type": "object",
-          "required": [
-            "entityType",
-            "entityId"
-          ],
+          "required": ["entityType", "entityId"],
           "properties": {
             "entityType": {
               "const": "program"
@@ -669,9 +618,7 @@
         {
           "description": "A Firebolt compliant representation of the remaining entity types.",
           "type": "object",
-          "required": [
-            "entityId"
-          ],
+          "required": ["entityId"],
           "properties": {
             "entityId": {
               "$ref": "#/definitions/Identifier"
@@ -705,9 +652,7 @@
         },
         {
           "type": "object",
-          "required": [
-            "data"
-          ],
+          "required": ["data"],
           "properties": {
             "action": {
               "const": "playback"
@@ -762,9 +707,7 @@
             },
             "data": {
               "type": "object",
-              "required": [
-                "query"
-              ],
+              "required": ["query"],
               "properties": {
                 "query": {
                   "type": "string"
@@ -805,9 +748,7 @@
             },
             "data": {
               "type": "object",
-              "required": [
-                "sectionName"
-              ],
+              "required": ["sectionName"],
               "properties": {
                 "sectionName": {
                   "type": "string"
@@ -842,18 +783,14 @@
         },
         {
           "type": "object",
-          "required": [
-            "data"
-          ],
+          "required": ["data"],
           "properties": {
             "action": {
               "const": "discovery"
             },
             "data": {
               "type": "object",
-              "required": [
-                "query"
-              ],
+              "required": ["query"],
               "properties": {
                 "query": {
                   "type": "string"
@@ -898,20 +835,14 @@
         },
         {
           "type": "object",
-          "required": [
-            "data"
-          ],
+          "required": ["data"],
           "properties": {
             "action": {
               "const": "entityAppSelection"
             },
             "data": {
               "type": "object",
-              "required": [
-                "query",
-                "entity",
-                "apps"
-              ],
+              "required": ["query", "entity", "apps"],
               "properties": {
                 "query": {
                   "type": "string"
@@ -1030,9 +961,7 @@
                 "exclude": true
               }
             ],
-            "menusIds": [
-              "123"
-            ]
+            "menusIds": ["123"]
           }
         }
       ]
@@ -1055,9 +984,7 @@
             },
             "data": {
               "type": "object",
-              "required": [
-                "operation"
-              ],
+              "required": ["operation"],
               "properties": {
                 "operation": {
                   "type": "string",
@@ -1281,18 +1208,11 @@
             },
             "data": {
               "type": "object",
-              "required": [
-                "interface"
-              ],
+              "required": ["interface"],
               "properties": {
                 "interface": {
                   "type": "string",
-                  "enum": [
-                    "hdmi",
-                    "rca",
-                    "vga",
-                    "etc..."
-                  ]
+                  "enum": ["hdmi", "rca", "vga", "etc..."]
                 },
                 "number": {
                   "type": "integer",
@@ -1457,10 +1377,7 @@
                     }
                   },
                   "propertyNames": {
-                    "enum": [
-                      "direction",
-                      "speed"
-                    ]
+                    "enum": ["direction", "speed"]
                   }
                 }
               ]
@@ -1522,10 +1439,7 @@
                     }
                   },
                   "propertyNames": {
-                    "enum": [
-                      "direction",
-                      "seconds"
-                    ]
+                    "enum": ["direction", "seconds"]
                   }
                 }
               ]
@@ -1596,10 +1510,7 @@
                     }
                   },
                   "propertyNames": {
-                    "enum": [
-                      "direction",
-                      "count"
-                    ]
+                    "enum": ["direction", "count"]
                   }
                 }
               ]
@@ -1763,10 +1674,7 @@
       "properties": {
         "direction": {
           "type": "string",
-          "enum": [
-            "forward",
-            "backward"
-          ]
+          "enum": ["forward", "backward"]
         }
       }
     },
@@ -1792,9 +1700,7 @@
           "pattern": "^xrn:firebolt:intent:(app|platform):[a-zA-Z]+$"
         }
       },
-      "required": [
-        "type"
-      ]
+      "required": ["type"]
     }
   }
 }

--- a/src/schemas/intents.json
+++ b/src/schemas/intents.json
@@ -798,15 +798,7 @@
                 "filters": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "key": {
-                        "type": "string"
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
+                    "$ref": "#/definitions/Filter"
                   },
                   "minItems": 1,
                   "maxItems": 100
@@ -814,18 +806,7 @@
                 "keywords": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "keyword": {
-                        "type": "string"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "appId": {
-                        "$ref": "#/definitions/Identifier"
-                      }
-                    }
+                    "$ref": "#/definitions/Keyword"
                   },
                   "minItems": 1,
                   "maxItems": 100
@@ -854,6 +835,42 @@
                 }
               }
             }
+          }
+        }
+      ],
+      "examples": [
+        {
+          "action": "contentDiscovery",
+          "context": {
+            "source": "voice"
+          },
+          "data": {
+            "query": "Bill Murray Comedies in 4K",
+            "filters": [
+              {
+                "key": "videoResolution",
+                "value": "UHD"
+              }
+            ],
+            "keywords": [
+              {
+                "keyword": "Bill Murray",
+                "type": "Person",
+                "appId": "FooApp"
+              },
+              {
+                "keyword": "Comedies",
+                "type": "Genre",
+                "appId": "FooApp"
+              }
+            ],
+            "menus": ["abcdef", "ghijkl"],
+            "federation": [
+              {
+                "appId": "BarApp",
+                "exclude": false
+              }
+            ]
           }
         }
       ]
@@ -1703,6 +1720,31 @@
     },
     "Identifier": {
       "type": "string"
+    },
+    "Filter": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "Keyword": {
+      "type": "object",
+      "properties": {
+        "keyword": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "appId": {
+          "$ref": "#/definitions/Identifier"
+        }
+      }
     },
     "DirectionalOperation": {
       "type": "object",


### PR DESCRIPTION
This adds the optional `filters` and `keywords` properties to the payload of the ContentDiscoveryIntent. The presence of these properties allow for context-aware systems to communicate their context back to an aggregated experience.

As an example, a catalog-aware discovery system on a given distribution platform may want to pass catalog-specific context downstream to an aggregated experience to meet a particular product requirement.

## Filters

~If the `filters` property is present, a catalog-aware system has determined that a user search results exist for a particular `programType` and/or `offeringType`. This context may be used to power behavior in an aggregated experience.~

`filters` are just hints that can be applied to a subsequent search from the aggregated experience. They are modeled as:
```typescript
type Filter = {
  key: String,
  value: String
}
```

## Keywords

Some content discovery systems require special treatment of content belonging to particular providers. The presence of the `keywords` property indicates that a catalog-aware system has determined that  a particular app on the platform has advertised itself as having results pertinent to the user's query. An aggregated experience may execute business logic given this knowledge. Keywords are modeled as:
```typescript
type Keyword = {
  keyword: String,
  type: String,
  appId: String
}
```