### PR TITLE
Fix/sentence case commits

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,1 +1,6 @@
-{ "extends": ["@commitlint/config-conventional"] }
+{
+    "extends": ["@commitlint/config-conventional"],
+    "rules": {
+        "subject-case": [2, "always", "sentence-case"]
+    }
+}


### PR DESCRIPTION
This adds a rule to the .commitlintrc.json file that allows for subjects to have capitalization and punctuation (I hope)