### PR TITLE
ci: update release assets

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -26,21 +26,13 @@
       }
     ],
     [
-      "@semantic-release/github",
-      {
-        "assets": [
-          {
-            "path": "dist/**",
-            "label": "JavaScript SDK, Markdown Docs, Fully Assembled Firebolt Spec"
-          }
-        ]
-      }
+      "@semantic-release/github"
     ],
     [
       "@semantic-release/git",
       {
         "assets": [
-          "src/**",
+          "dist/**",
           "package.json",
           "package-lock.json",
           "CHANGELOG.md",


### PR DESCRIPTION
Some changes I hope will affect the "Assets" that GitHub publishes with releases.