### PR TITLE
Changes to release automation

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -39,5 +39,8 @@ jobs:
     - run: npm run build:sdk
     - run: npm run dist:declarations
     - run: npm run dist:sdk
+    - run: |
+        npm run build:docs
+        npm run dist:docs
     - run: npm run test
 

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          repo-token: ${{ secrets.SEMANTIC_RELEASE_BOT_PAT }}
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
@@ -40,5 +42,5 @@ jobs:
           npm run dist:docs
       - name: Release to GitHub
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_BOT_PAT }} # <-- Allows semantic-release-bot to push changes to protected branches
         run: npx semantic-release

--- a/.releaserc
+++ b/.releaserc
@@ -26,23 +26,16 @@
       }
     ],
     [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
+    [
       "@semantic-release/github"
     ],
     [
-      "@semantic-release/git",
-      {
-        "assets": [
-          "dist/**",
-          "package.json",
-          "package-lock.json",
-          "CHANGELOG.md",
-          "CONTRIBUTING.md",
-          "LICENSE",
-          "NOTICE",
-          "COPYING"
-        ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
+      "@semantic-release/git"
     ]
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@firebolt-js/schemas": "0.4.0",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
+        "@semantic-release/npm": "^9.0.1",
         "ajv": "^6.12.6",
         "husky": "^8.0.0",
         "jest": "^28.1.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@firebolt-js/schemas": "0.4.0",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
+    "@semantic-release/npm": "^9.0.1",
     "ajv": "^6.12.6",
     "husky": "^8.0.0",
     "jest": "^28.1.0",


### PR DESCRIPTION
- Automation won't check `dist/` folder into source control.
- Should now update the `package.json` file with the release job.
- Generate docs as part of PR validation
- Will not publish to `npm` [see .releaserc](https://github.com/rdkcentral/firebolt-core-sdk/pull/61/files#diff-644a8fae29c8e8b6ad5405a2e66c718a3b27f2e12581b7c5e00396d32b3e5cdeR33) for `npmPublish` option.