### PR TITLE
chore: manual changelog edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,41 +11,20 @@
 
 * **extensions:** extensions module ([7cf4128](https://github.com/rdkcentral/firebolt-core-sdk/commit/7cf412819de8bc9749d51af2de923556924ae564)), closes [#46](https://github.com/rdkcentral/firebolt-core-sdk/issues/46)
 
-# [0.9.0-next.1](https://github.com/rdkcentral/firebolt-core-sdk/compare/v0.8.1-next.1...v0.9.0-next.1) (2022-09-14)
-
-
-### Bug Fixes
-
-* **device:** add device version firmware property ([ef12ec0](https://github.com/rdkcentral/firebolt-core-sdk/commit/ef12ec083591837e9a0c31d993f4e916810b11bc)), closes [#54](https://github.com/rdkcentral/firebolt-core-sdk/issues/54)
-
-
-### Features
-
-* **extensions:** extensions module ([7cf4128](https://github.com/rdkcentral/firebolt-core-sdk/commit/7cf412819de8bc9749d51af2de923556924ae564)), closes [#46](https://github.com/rdkcentral/firebolt-core-sdk/issues/46)
-
-## [0.8.1-next.1](https://github.com/rdkcentral/firebolt-core-sdk/compare/v0.8.0...v0.8.1-next.1) (2022-09-08)
-
-
-### Bug Fixes
-
-* **lifecycle:** lifecycle state api returns correct state in all circumstances ([31e405c](https://github.com/rdkcentral/firebolt-core-sdk/commit/31e405c124d29a3e87294dc4b356ff8df9972af8))
-
-# Release Notes
-
-## 0.8.1
+# 0.8.1
 
 - Added Device.version().firmware to surface the underlying hardware firmware version
 - Added Device.version().api to surface the latest Firebolt API supported by this device
 - Deprecated Device.version().os which does not have a formal specification. Use `firmware` instead.
 
-## 0.8.0
+# 0.8.0
 
 - Tune Intents are now supported in `navigateTo` events
 - Added TypeScript declarations for Settings and Events
 - Fixed/Removed test-enabling code from SDK
 - Fixed bug where the SDK would initialize itself even when not being used
 
-## 0.7.0
+# 0.7.0
 
 - Removed all `bigint` types from TypeScript declarations, in favor of `number`, since bigint is not widely supported across browsers. This changes impacts:
     - Device.screenResolution
@@ -68,12 +47,12 @@ Should become:
 const res:[number, number] = await Device.screenResolution()
 ```
 
-## 0.6.2
+# 0.6.2
 
 - Fixed incompatibility with Jest 26 due to [jest/issues/10565](https://github.com/facebook/jest/issues/10565)
 
 
-## 0.6.1
+# 0.6.1
 
 - Changed Firebolt build to use `.mjs` extension
 - Firebolt builds are now pure ES6 modules, not bundled with Webpack
@@ -83,7 +62,7 @@ const res:[number, number] = await Device.screenResolution()
 - Added TypeScript declaration for `clear` method (all modules)
 - Changed `{}` return type to `void` for listener callbacks
 
-## 0.6.0
+# 0.6.0
 
 - Added support for [rdkcentral/mock-firebolt](https://github.com/rdkcentral/mock-firebolt/) via a WebSocket transport layer
 - Deprecated Accessibility.closedCaptions and voiceGuidance, created properties for Accessibility.closedCaptionsSettings and voiceGuidanceSettings, which support subscribers
@@ -92,7 +71,7 @@ const res:[number, number] = await Device.screenResolution()
 - Added proper TypeScript declarations for Discovery.entityInfo and Discovery.purchasedContent
 - Fixed race condition w/ Transport Layer initialization
 
-## 0.5.2
+# 0.5.2
 
 - Added Parameters modules
 - Fixed typo in Advertising.config example result for docs/Mock
@@ -102,12 +81,12 @@ const res:[number, number] = await Device.screenResolution()
 - Updated `Discovery.watchNext` to use `LocalizedString` for `title` and each property of `images`
 - Added `OfferingType` and `ProgramType` parameters to `Discovery.purchasedContent`
 
-## 0.5.1
+# 0.5.1
 
 - Cleaned up errors in various Mock responses
 - Methods that call private Metrics APIs, e.g. Lifecycle.ready, now do so **after** promise resolution
 
-## 0.5.0
+# 0.5.0
 
 - Updated TS declarations (.d.ts) to detect which event is being passed to `.listen()` methods
 - Updated all `listen()` and `once()` methods to return a `Promise`


### PR DESCRIPTION
When I was debugging the release automation, the tool made several duplicate edits to CHANGELOG.md. I removed the duplicates.