### PR TITLE
build: Build SDK before npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,12 @@ util/*
 build/*
 test/*
 node_modules/*
+.github/*
+.husky/*
 .DS_Store
 merge-script-control-flow.svg
-*.config.js
+*.config.js*
+.releaserc
+.commitlintrc.json
+push-docs.sh
+tsconfig.json

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "publish:docs": "npm run build:docs && sh push-docs.sh",
     "publish:word": "mkdir -p dist/word/schemas && cd dist/docs && find . -iname \"*.md\" -type f -exec sh -c 'pandoc \"${0}\" -o \"../word/${0%.md}.docx\"' {} \\;",
     "everything": "npm run fs:setup && npm run validate:each && npm run build:openrpc && npm run validate:assembled && npm run build:sdk && npm run dist:sdk && npm run dist:declarations && npm run test && npm run build:docs && npm run dist:docs",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "prepack": "npm run fs:setup && npm run build:openrpc && npm run build:sdk && npm run dist:sdk && npm run dist:declarations"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Putting in the `prepack` hook in the package.json makes it so that the SDK gets built and placed into `dist/` as expected prior to being published to NPM. The files built during this step can then be included in the `tar.gz` file that is included with the npm distro, but also the github release.

This also adds more files to `.npmignore`, or files we don't want to publish in a release distro. Let me know if there is anything I omitted that you think needs to stay.