### PR TITLE
ci: Release to npm and github on merge to next

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -1,6 +1,9 @@
 name: Release to GitHub
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - 'next'
 env:
   HUSKY: 0
 jobs:


### PR DESCRIPTION
The manual trigger is still available to repo admins.